### PR TITLE
TST: ndimage: generalize gaussian_filter axes tests

### DIFF
--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -3,6 +3,7 @@ import functools
 import itertools
 import math
 import numpy
+import numpy as np
 
 from numpy.testing import (assert_equal, assert_allclose,
                            assert_array_almost_equal,
@@ -692,67 +693,75 @@ class TestNdimageFilters:
         ndimage.gaussian_filter(input, 1.0, output=input)
         assert_array_almost_equal(output1, input)
 
+    @pytest.mark.parametrize(('filter_func', 'size0', 'size'),
+                             [(ndimage.gaussian_filter, 0, 1.0),
+                              (ndimage.uniform_filter, 1, 3.0),
+                              (ndimage.minimum_filter, 1, 3.0),
+                              (ndimage.maximum_filter, 1, 3.0)])
     @pytest.mark.parametrize(
         'axes',
         tuple(itertools.combinations(range(-3, 3), 1))
         + tuple(itertools.combinations(range(-3, 3), 2))
         + ((0, 1, 2),))
-    def test_gauss_axes(self, axes):
+    def test_filter_axes(self, filter_func, size0, size, axes):
         array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
-        sigma = 1.0
+
         axes = tuple(ax % array.ndim for ax in axes)
         if len(tuple(set(axes))) != len(axes):
             # parametrized cases with duplicate axes raise an error
             with pytest.raises(ValueError, match="axes must be unique"):
-                ndimage.gaussian_filter(array, sigma, axes=axes)
+                filter_func(array, size, axes=axes)
             return
-        output = ndimage.gaussian_filter(array, sigma, axes=axes)
+        output = filter_func(array, size, axes=axes)
 
-        # result should be equivalent to sigma=0.0 on unfiltered axes
-        all_sigmas = (sigma if ax in axes else 0.0 for ax in range(array.ndim))
-        expected = ndimage.gaussian_filter(array, all_sigmas)
+        # result should be equivalent to sigma=0.0/size=1 on unfiltered axes
+        all_sizes = (size if ax in axes else size0 for ax in range(array.ndim))
+        expected = filter_func(array, all_sizes)
+        assert_allclose(output, expected)
+
+    kwargs_gauss = dict(radius=[4, 2, 3], order=[0, 1, 2],
+                        mode=['reflect', 'nearest', 'constant'])
+    kwargs_other = dict(origin=(-1, 0, 1),
+                        mode=['reflect', 'nearest', 'constant'])
+    @pytest.mark.parametrize("filter_func, size0, size, kwargs",
+                             [(ndimage.gaussian_filter, 0, 2, kwargs_gauss),
+                              (ndimage.uniform_filter, 1, 3, kwargs_other),
+                              (ndimage.maximum_filter, 1, 3, kwargs_other),
+                              (ndimage.minimum_filter, 1, 3, kwargs_other)])
+    @pytest.mark.parametrize('axes', itertools.combinations(range(-3, 3), 2))
+    def test_filter_axes_kwargs(self, filter_func, size0, size, kwargs, axes):
+        array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
+
+        kwargs = {key: np.array(val) for key, val in kwargs.items()}
+        axes = np.array(axes)
+        n_axes = axes.size
+
+        # form kwargs that specify only the axes in `axes`
+        reduced_kwargs = {key:val[axes] for key, val in kwargs.items()}
+        if len(set(axes % array.ndim)) != len(axes):
+            # parametrized cases with duplicate axes raise an error
+            with pytest.raises(ValueError, match="axes must be unique"):
+                filter_func(array, [size]*n_axes, axes=axes, **reduced_kwargs)
+            return
+
+        output = filter_func(array, [size]*n_axes, axes=axes, **reduced_kwargs)
+
+        # result should be equivalent to sigma=0.0/size=1 on unfiltered axes
+        size_3d = np.full(array.ndim, fill_value=size0)
+        size_3d[axes] = size
+        expected = filter_func(array, size_3d, **kwargs)
         assert_allclose(output, expected)
 
     @pytest.mark.parametrize(
-        'axes', tuple(itertools.combinations(range(-3, 3), 2))
-    )
-    def test_gauss_axes_kwargs(self, axes):
-        array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
-        sigma = (1.0, 0.5)
-        radius = (4, 2)
-        order = (0, 1)
-        mode = ('reflect', 'nearest')
-        axes = tuple(ax % array.ndim for ax in axes)
-        kwargs = dict(sigma=sigma, radius=radius, mode=mode, order=order)
-        if len(tuple(set(axes))) != len(axes):
-            # parametrized cases with duplicate axes raise an error
-            with pytest.raises(ValueError, match="axes must be unique"):
-                ndimage.gaussian_filter(array, axes=axes, **kwargs)
-            return
-        output = ndimage.gaussian_filter(array, axes=axes, **kwargs)
-
-        # result should be equivalent to sigma=0.0 on unfiltered axes
-        sigma_3d = [0,] * array.ndim
-        sigma_3d[axes[0]] = sigma[0]
-        sigma_3d[axes[1]] = sigma[1]
-        radius_3d = [0,] * array.ndim
-        radius_3d[axes[0]] = radius[0]
-        radius_3d[axes[1]] = radius[1]
-        mode_3d = [0,] * array.ndim
-        mode_3d[axes[0]] = mode[0]
-        mode_3d[axes[1]] = mode[1]
-        order_3d = [0,] * array.ndim
-        order_3d[axes[0]] = order[0]
-        order_3d[axes[1]] = order[1]
-        kwargs = dict(sigma=sigma_3d, radius=radius_3d, mode=mode_3d,
-                      order=order_3d)
-        expected = ndimage.gaussian_filter(array, **kwargs)
-        assert_allclose(output, expected)
-
+        'filter_func, size',
+        [(ndimage.gaussian_filter, 1.0),
+         (ndimage.uniform_filter, 3),
+         (ndimage.minimum_filter, 3),
+         (ndimage.maximum_filter, 3)])
     @pytest.mark.parametrize(
         'axes', [(1.5,), (0, 1, 2, 3), (3,), (-4,)]
     )
-    def test_gauss_invalid_axes(self, axes):
+    def test_filter_invalid_axes(self, filter_func, size, axes):
         array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
         if any(isinstance(ax, float) for ax in axes):
             error_class = TypeError
@@ -761,26 +770,37 @@ class TestNdimageFilters:
             error_class = ValueError
             match = "out of range"
         with pytest.raises(error_class, match=match):
-            ndimage.gaussian_filter(array, sigma=1.0, axes=axes)
+            ndimage.gaussian_filter(array, size, axes=axes)
 
-    @pytest.mark.parametrize('tuple_ndim', [1, 3])
-    @pytest.mark.parametrize('mismatched',
-                             ['radius', 'mode', 'sigma', 'order'])
-    def test_gauss_axes_tuple_length_mismatch(self, tuple_ndim, mismatched):
+    @staticmethod
+    def _cases_axes_tuple_length_mismatch():
+        # Generate combinations of filter function, valid kwargs, and
+        # keyword-value pairs for which the value will become with mismatched
+        # (invalid) size
+        filter_func = ndimage.gaussian_filter
+        kwargs = {'radius': 3, 'mode': 'constant', 'sigma': 1.0, 'order': 0}
+        for key, val in kwargs.items():
+            yield filter_func, kwargs, key, val
+
+        filter_funcs = [ndimage.uniform_filter, ndimage.minimum_filter,
+                        ndimage.maximum_filter]
+        kwargs = {'size': 3, 'mode': 'constant', 'origin': 0}
+        for filter_func in filter_funcs:
+            for key, val in kwargs.items():
+                yield filter_func, kwargs, key, val
+
+    @pytest.mark.parametrize('n_mismatch', [1, 3])
+    @pytest.mark.parametrize('filter_func, kwargs, key, val',
+                             _cases_axes_tuple_length_mismatch())
+    def test_filter_tuple_length_mismatch(self, n_mismatch, filter_func,
+                                          kwargs, key, val):
+        # Test for the intended RuntimeError when a kwargs has an invalid size
         array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
-        kwargs = dict(sigma=1.0, radius=(3, 3), axes=(0, 1), mode='constant')
-        if mismatched == 'radius':
-            kwargs['radius'] = (3,) * tuple_ndim
-        elif mismatched == 'mode':
-            kwargs['mode'] = ['constant'] * tuple_ndim
-        elif mismatched == 'sigma':
-            kwargs['sigma'] = (1.0,) * tuple_ndim
-        elif mismatched == 'order':
-            kwargs['order'] = (0,) * tuple_ndim
-
+        kwargs = dict(**kwargs, axes=(0, 1))
+        kwargs[key] = (val,) * n_mismatch
         err_msg = "sequence argument must have length equal to input rank"
         with pytest.raises(RuntimeError, match=err_msg):
-            ndimage.gaussian_filter(array, **kwargs)
+            filter_func(array, **kwargs)
 
     @pytest.mark.parametrize('dtype', types + complex_types)
     def test_prewitt01(self, dtype):

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -3,7 +3,6 @@ import functools
 import itertools
 import math
 import numpy
-import numpy as np
 
 from numpy.testing import (assert_equal, assert_allclose,
                            assert_array_almost_equal,
@@ -704,6 +703,7 @@ class TestNdimageFilters:
         + tuple(itertools.combinations(range(-3, 3), 2))
         + ((0, 1, 2),))
     def test_filter_axes(self, filter_func, size0, size, axes):
+        # Note: `size` is called `sigma` in `gaussian_filter`
         array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
 
         axes = tuple(ax % array.ndim for ax in axes)
@@ -732,8 +732,8 @@ class TestNdimageFilters:
     def test_filter_axes_kwargs(self, filter_func, size0, size, kwargs, axes):
         array = numpy.arange(6 * 8 * 12, dtype=numpy.float64).reshape(6, 8, 12)
 
-        kwargs = {key: np.array(val) for key, val in kwargs.items()}
-        axes = np.array(axes)
+        kwargs = {key: numpy.array(val) for key, val in kwargs.items()}
+        axes = numpy.array(axes)
         n_axes = axes.size
 
         # form kwargs that specify only the axes in `axes`
@@ -747,7 +747,7 @@ class TestNdimageFilters:
         output = filter_func(array, [size]*n_axes, axes=axes, **reduced_kwargs)
 
         # result should be equivalent to sigma=0.0/size=1 on unfiltered axes
-        size_3d = np.full(array.ndim, fill_value=size0)
+        size_3d = numpy.full(array.ndim, fill_value=size0)
         size_3d[axes] = size
         expected = filter_func(array, size_3d, **kwargs)
         assert_allclose(output, expected)
@@ -770,7 +770,7 @@ class TestNdimageFilters:
             error_class = ValueError
             match = "out of range"
         with pytest.raises(error_class, match=match):
-            ndimage.gaussian_filter(array, size, axes=axes)
+            filter_func(array, size, axes=axes)
 
     @staticmethod
     def _cases_axes_tuple_length_mismatch():

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -695,9 +695,9 @@ class TestNdimageFilters:
 
     @pytest.mark.parametrize(('filter_func', 'size0', 'size'),
                              [(ndimage.gaussian_filter, 0, 1.0),
-                              (ndimage.uniform_filter, 1, 3.0),
-                              (ndimage.minimum_filter, 1, 3.0),
-                              (ndimage.maximum_filter, 1, 3.0)])
+                              (ndimage.uniform_filter, 1, 3),
+                              (ndimage.minimum_filter, 1, 3),
+                              (ndimage.maximum_filter, 1, 3)])
     @pytest.mark.parametrize(
         'axes',
         tuple(itertools.combinations(range(-3, 3), 1))
@@ -724,7 +724,7 @@ class TestNdimageFilters:
     kwargs_other = dict(origin=(-1, 0, 1),
                         mode=['reflect', 'nearest', 'constant'])
     @pytest.mark.parametrize("filter_func, size0, size, kwargs",
-                             [(ndimage.gaussian_filter, 0, 2, kwargs_gauss),
+                             [(ndimage.gaussian_filter, 0, 1.0, kwargs_gauss),
                               (ndimage.uniform_filter, 1, 3, kwargs_other),
                               (ndimage.maximum_filter, 1, 3, kwargs_other),
                               (ndimage.minimum_filter, 1, 3, kwargs_other)])
@@ -778,13 +778,13 @@ class TestNdimageFilters:
         # keyword-value pairs for which the value will become with mismatched
         # (invalid) size
         filter_func = ndimage.gaussian_filter
-        kwargs = {'radius': 3, 'mode': 'constant', 'sigma': 1.0, 'order': 0}
+        kwargs = dict(radius=3, mode='constant', sigma=1.0, order=0)
         for key, val in kwargs.items():
             yield filter_func, kwargs, key, val
 
         filter_funcs = [ndimage.uniform_filter, ndimage.minimum_filter,
                         ndimage.maximum_filter]
-        kwargs = {'size': 3, 'mode': 'constant', 'origin': 0}
+        kwargs = dict(size=3, mode='constant', origin=0)
         for filter_func in filter_funcs:
             for key, val in kwargs.items():
                 yield filter_func, kwargs, key, val


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/18261

#### What does this implement/fix?
Here's my take on generalizing the existing `gaussian_filter` `axes` tests.

#### Additional information
I restored the original test file in the first commit, added my generalizations of the tests in the second commit, and added back your (unmodified) `test_minmax_nonseparable_axes` test in the third. Therefore, to minimize the diff, please see just the middle commit f772bc221004827f784eed6111f2f84842d3e0d7.